### PR TITLE
Updated versions.json

### DIFF
--- a/versions/versions.json
+++ b/versions/versions.json
@@ -613,7 +613,7 @@
             "url": "https://assets.minecraft.net/1_9-pre5/minecraft_server.jar"
         },
         "1.0.1": {
-            "url": "http://files.betacraft.uk/server-archive/release/1.0.0/1.0.1.jar"
+            "url": "http://files.betacraft.uk/server-archive/release/1.0/1.0.1.jar"
         },
         "1.1": {
             "url": "http://files.betacraft.uk/server-archive/release/1.1/1.1.jar"


### PR DESCRIPTION
Fixed unreported issue of 1.0.1 server not downloading because of an incorrect URL.